### PR TITLE
Add and remove other field from Visitor

### DIFF
--- a/app.js
+++ b/app.js
@@ -146,7 +146,9 @@ app.delete('/log/:id', passportConfig.isAuthenticated, logController.deleteLog);
 app.get('/visitor', passportConfig.isAuthenticated, visitorController.getVisitors);
 app.get('/visitor/:id', passportConfig.isAuthenticated, visitorController.getVisitor);
 app.put('/visitor/:id', passportConfig.isAuthenticated, visitorController.putVisitor);
+app.put('/visitor/:id/field', passportConfig.isAuthenticated, visitorController.addFieldVisitor);
 app.post('/visitor', passportConfig.isAuthenticated, visitorController.postVisitor);
+app.delete('/visitor/:id/field', passportConfig.isAuthenticated, visitorController.removeFieldVisitor);
 
 /**
  * Dashboard app routes

--- a/controllers/visitor.js
+++ b/controllers/visitor.js
@@ -1,4 +1,5 @@
 const Visitor = require('../models/Visitor');
+const mongoose = require('mongoose');
 
 /**
  * GET /visitor
@@ -82,6 +83,47 @@ exports.putVisitor = (req, res, next) => {
     otherFields: req.body.otherFields
   };
   Visitor.findByIdAndUpdate(id, body, { new: true }, (err, visitor) => {
+    if (err) {
+      return next(err);
+    }
+    res.json({ visitor });
+    req.flash('success', { msg: 'Visitor information has been updated.' });
+    // todo: render all visitors page
+  });
+};
+
+/**
+ * PUT /visitor/:id/field
+ * Add a new field with it's value to a visitor with specified id
+ */
+exports.addFieldVisitor = (req, res, next) => {
+  const id = req.params.id;
+  const newField = {
+    label: req.body.label,
+    value: req.body.value
+  };
+  Visitor.findByIdAndUpdate(id, {
+    $addToSet: { otherFields: newField }
+  }, { new: true }, (err, visitor) => {
+    if (err) {
+      return next(err);
+    }
+    res.json({ visitor });
+    req.flash('success', { msg: 'Visitor information has been updated.' });
+    // todo: render all visitors page
+  });
+};
+
+/**
+ * DEL /visitor/:id/field
+ * Remove an existing field with it's value from a visitor with specified id
+ */
+exports.removeFieldVisitor = (req, res, next) => {
+  const id = req.params.id;
+  const label = req.body.label;
+  Visitor.findByIdAndUpdate(id, {
+    $pull: { otherFields: { label } }
+  }, { new: true }, (err, visitor) => {
     if (err) {
       return next(err);
     }

--- a/controllers/visitor.js
+++ b/controllers/visitor.js
@@ -1,5 +1,4 @@
 const Visitor = require('../models/Visitor');
-const mongoose = require('mongoose');
 
 /**
  * GET /visitor


### PR DESCRIPTION
This PR add 2 new endpoints:
- `POST /visitor/:id/field`, to add new other field. `:id` is the `ObjectId` of the user. The required request body is as follows:
```
{
  "label": "label",
  "value": "value"
}
```
- `DEL /visitor/:id/field`, to delete other field based on `label`. `:id` is the `ObjectId` of the user. The required request body is as follows:
```
{
  "label": "label"
}
```