### PR TITLE
ObjectId validator middleware

### DIFF
--- a/app.js
+++ b/app.js
@@ -45,6 +45,7 @@ const passportConfig = require('./config/passport');
 /**
  * Middlewares.
  */
+const objectId = require('./middlewares/objectId');
 const role = require('./middlewares/role');
 
 /**
@@ -139,16 +140,16 @@ app.post('/account/password', passportConfig.isAuthenticated, userController.pos
 app.post('/account/delete', passportConfig.isAuthenticated, userController.postDeleteAccount);
 app.get('/account/unlink/:provider', passportConfig.isAuthenticated, userController.getOauthUnlink);
 app.get('/log', passportConfig.isAuthenticated, logController.getLogs);
-app.get('/log/:id', passportConfig.isAuthenticated, logController.getLog);
+app.get('/log/:id', passportConfig.isAuthenticated, objectId.isParamValid, logController.getLog);
 app.post('/log', passportConfig.isAuthenticated, logController.postLog);
-app.put('/log/:id', passportConfig.isAuthenticated, logController.putLog);
-app.delete('/log/:id', passportConfig.isAuthenticated, logController.deleteLog);
+app.put('/log/:id', passportConfig.isAuthenticated, objectId.isParamValid, logController.putLog);
+app.delete('/log/:id', passportConfig.isAuthenticated, objectId.isParamValid, logController.deleteLog);
 app.get('/visitor', passportConfig.isAuthenticated, visitorController.getVisitors);
-app.get('/visitor/:id', passportConfig.isAuthenticated, visitorController.getVisitor);
-app.put('/visitor/:id', passportConfig.isAuthenticated, visitorController.putVisitor);
-app.put('/visitor/:id/field', passportConfig.isAuthenticated, visitorController.addFieldVisitor);
+app.get('/visitor/:id', passportConfig.isAuthenticated, objectId.isParamValid, visitorController.getVisitor);
+app.put('/visitor/:id', passportConfig.isAuthenticated, objectId.isParamValid, visitorController.putVisitor);
+app.put('/visitor/:id/field', passportConfig.isAuthenticated, objectId.isParamValid, visitorController.addFieldVisitor);
 app.post('/visitor', passportConfig.isAuthenticated, visitorController.postVisitor);
-app.delete('/visitor/:id/field', passportConfig.isAuthenticated, visitorController.removeFieldVisitor);
+app.delete('/visitor/:id/field', passportConfig.isAuthenticated, objectId.isParamValid, visitorController.removeFieldVisitor);
 
 /**
  * Dashboard app routes

--- a/middlewares/objectId.js
+++ b/middlewares/objectId.js
@@ -1,0 +1,9 @@
+const mongoose = require('mongoose');
+
+exports.isParamValid = (req, res, next) => {
+  if (mongoose.Types.ObjectId.isValid(req.params.id)) {
+    return next();
+  }
+  req.flash('errors', { msg: 'Id is not valid.' });
+  res.redirect('/');
+};


### PR DESCRIPTION
If user insert an invalid `ObjectId` as a param for some endpoints (e.g: `log/:id`). Sometimes `mongoose` return a `TypeError` which is not informative to end user. This middleware validates `id` parameter to check if it's a valid `ObjectId` and will return error on front end if `id` is an invalid `ObjectId`.