### PR TITLE
Add soft-delete related properties to Visitor schema

### DIFF
--- a/controllers/visitor.js
+++ b/controllers/visitor.js
@@ -10,7 +10,7 @@ exports.getVisitors = (req, res, next) => {
     limit: Number(req.query.limit) || 20,
     sort: { createdAt: -1 }
   };
-  Visitor.paginate({ deleted: false || null }, query, (err, visitors) => {
+  Visitor.paginate({ deleted: false }, query, (err, visitors) => {
     if (err) {
       return next(err);
     }

--- a/models/Visitor.js
+++ b/models/Visitor.js
@@ -13,7 +13,10 @@ const visitorSchema = new mongoose.Schema({
   otherFields: [{
     label: String,
     value: String
-  }]
+  }],
+  deleted: { type: Boolean, default: false },
+  deletedAt: Date,
+  deletedBy: { type: mongoose.Schema.Types.ObjectId, ref: 'Visitor' }
 }, { timestamps: true });
 
 visitorSchema.plugin(paginate);


### PR DESCRIPTION
Previously to fetch all visitor, we search whether the property of `deleted` is either `false` or `null`. To make things easier, I propose to just add the `soft-delete` properties to `Visitor` schema and omit the `deleted === null` condition.